### PR TITLE
Added multiple key searches for same keyword, proper file formats for output, StartOS support (base64 option), and progress tracker on terminal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG REVISION
 LABEL org.opencontainers.image.title="Fast Tor Onion Service vanity address generator"
 LABEL org.opencontainers.image.description="This tool generates Tor Onion Service keypair with onion address that has a specified prefix"
 LABEL org.opencontainers.image.authors="Alexander Yastrebov <yastrebov.alex@gmail.com>"
-LABEL org.opencontainers.image.url="https://github.com/AlexanderYastrebov/onion-vanity-address"
+LABEL org.opencontainers.image.url="https://github.com/xannythepleb/onion-vanity-address"
 LABEL org.opencontainers.image.licenses="BSD-3-Clause"
 LABEL org.opencontainers.image.revision="${REVISION}"
 

--- a/README.md
+++ b/README.md
@@ -6,69 +6,197 @@ It can also generate vanity [client authorization](https://community.torproject.
 
 Compared to [similar tools](#similar-tools), it uses the [fastest search algorithm](#the-fastest-search-algorithm) 🚀
 
+## What's been added in this fork
+
+This fork adds several practical improvements for generating and managing multiple vanity Onion Service keys:
+
+* The tool now keeps searching until it has found three matching Onion Service addresses by default.
+* Use `--count` to choose how many matches to find before stopping.
+
+  * Example: `--count 1`
+  * Example: `--count 5`
+* Normal Tor output now writes each generated Onion Service keypair to its own directory named after the hostname.
+* Each normal Tor output directory contains the standard Onion Service files:
+
+  * `hostname`
+  * `hs_ed25519_public_key`
+  * `hs_ed25519_secret_key`
+* Use `--start9` to output the private key in the Start9 StartOS Tor plugin format.
+* Start9 output writes one file per generated hostname.
+* Each Start9 output file is named after the hostname and contains only the 88-character base64-encoded expanded secret key.
+* The live search status now updates in-place in the terminal instead of printing a new line for every update.
+* The progress report shows:
+
+  * elapsed search time
+  * total attempts tried
+  * attempts per second
+  * how many matching keys have been found
+  * how many are still remaining
+* When a matching key is found, the tool prints it immediately while continuing the search.
+* Large numbers are now shown in a short readable format.
+
+  * Example: `56.4M attempts/s`
+  * Example: `75.5B` total attempts
+
 ## Usage
 
 Install the tool locally and run:
+
 ```sh
-go install github.com/AlexanderYastrebov/onion-vanity-address@latest
-```
-```
-$ onion-vanity-address allium
-Found allium... in 12s after 558986486 attempts (48529996 attempts/s)
----
-hostname: alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion
-hs_ed25519_public_key: PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAAAC1ooweCbRP6ncFQs3NRyK40fRwaodrmH572D8py+tCQ==
-hs_ed25519_secret_key: PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAAAQEW4Rhot7oroPaETlAEG3GPAntvJ1agF2c7A2AXmBW3WqAH0oUZ1hySvvZl3hc9dSAIc49h1UuCPZacOWp4vQ
+go install github.com/xannythepleb/onion-vanity-address@latest
 ```
 
-or use the Docker image:
+By default the tool keeps searching until it has found three matching Onion Service addresses:
+
+```console
+$ onion-vanity-address test t3st testaddr
+Searching test,t3st,testaddr | elapsed 10s | tried 564.0M | 56.4M attempts/s | found 0/3 | remaining 3
+Found test... testabc...onion (1/3) after 12s and 676.8M attempts (56.4M attempts/s)
+Searching test,t3st,testaddr | elapsed 20s | tried 1.1B | 56.4M attempts/s | found 1/3 | remaining 2
+Found t3st... t3stxyz...onion (2/3) after 31s and 1.7B attempts (56.4M attempts/s)
+Searching test,t3st,testaddr | elapsed 40s | tried 2.3B | 56.4M attempts/s | found 2/3 | remaining 1
+Found test... testdef...onion (3/3) after 45s and 2.5B attempts (56.4M attempts/s)
+Wrote Tor service files to testabc...onion/
+Wrote Tor service files to t3stxyz...onion/
+Wrote Tor service files to testdef...onion/
+```
+
+The live `Searching ...` line is updated in-place while the tool is running. It is shown across multiple lines above only to demonstrate how the progress report changes over time.
+
+Use `--count` to choose how many matching addresses to find before stopping:
+
+```console
+$ onion-vanity-address --count 1 allium
+Searching allium | elapsed 10s | tried 485.3M | 48.5M attempts/s | found 0/1 | remaining 1
+Found allium... alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion (1/1) after 12s and 559.0M attempts (48.5M attempts/s)
+Wrote Tor service files to alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion/
+```
+
+Normal Tor output is written as a directory named after the hostname:
+
+```text
+alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion/
+├── hostname
+├── hs_ed25519_public_key
+└── hs_ed25519_secret_key
+```
+
+The `hostname` file contains the `.onion` address.
+
+The `hs_ed25519_public_key` and `hs_ed25519_secret_key` files can be used as the Onion Service key files expected by Tor.
+
+Use `--start9` to write the private key in the 88-character base64 format expected by Start9 StartOS's Tor plugin UI:
+
+```console
+$ onion-vanity-address --start9 --count 1 allium
+Searching allium | elapsed 10s | tried 485.3M | 48.5M attempts/s | found 0/1 | remaining 1
+Found allium... alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion (1/1) after 12s and 559.0M attempts (48.5M attempts/s)
+Wrote Start9 key to alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion
+```
+
+That file contains only the expanded secret key, base64-encoded.
+
+It should be 88 characters long and end in `==`.
+
+Example Start9 output file:
+
+```text
+alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion
+```
+
+Example file contents:
+
+```text
+YEQm98uujS4eH1tY6S9t0ThKbw8KzVwA6Ue3wAjOfE6cfq1Uxx4XHJb9x7oN0r2gO6rAVybr5kAy5VnPTrm9xQ==
+```
+
+You can also use `--start9` with multiple prefixes:
+
+```console
+$ onion-vanity-address --start9 --count 3 test t3st testaddr
+Searching test,t3st,testaddr | elapsed 10s | tried 564.0M | 56.4M attempts/s | found 0/3 | remaining 3
+Found test... testabc...onion (1/3) after 12s and 676.8M attempts (56.4M attempts/s)
+Searching test,t3st,testaddr | elapsed 20s | tried 1.1B | 56.4M attempts/s | found 1/3 | remaining 2
+Found t3st... t3stxyz...onion (2/3) after 31s and 1.7B attempts (56.4M attempts/s)
+Searching test,t3st,testaddr | elapsed 40s | tried 2.3B | 56.4M attempts/s | found 2/3 | remaining 1
+Found testaddr... testaddrabc...onion (3/3) after 2m8s and 7.2B attempts (56.4M attempts/s)
+Wrote Start9 key to testabc...onion
+Wrote Start9 key to t3stxyz...onion
+Wrote Start9 key to testaddrabc...onion
+```
+
+Or use the Docker image:
+
 ```sh
 docker pull ghcr.io/alexanderyastrebov/onion-vanity-address:latest
-docker run  ghcr.io/alexanderyastrebov/onion-vanity-address:latest allium
+docker run ghcr.io/alexanderyastrebov/onion-vanity-address:latest --count 1 allium
 ```
 
-To configure hidden service keypair decode base64-encoded secret key into `hs_ed25519_secret_key` file,
-remove `hs_ed25519_public_key` and `hostname` files and restart Tor service:
-```console
-$ echo PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAAAQEW4Rhot7oroPaETlAEG3GPAntvJ1agF2c7A2AXmBW3WqAH0oUZ1hySvvZl3hc9dSAIc49h1UuCPZacOWp4vQ | base64 -d > /var/lib/tor/hidden_service/hs_ed25519_secret_key
+With Start9 output:
 
-$ rm /var/lib/tor/hidden_service/hs_ed25519_public_key
-$ rm /var/lib/tor/hidden_service/hostname
-$ systemctl reload tor
-
-$ cat /var/lib/tor/hidden_service/hostname
-alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion
+```sh
+docker run ghcr.io/alexanderyastrebov/onion-vanity-address:latest --start9 --count 1 allium
 ```
 
 ### Multiple prefixes
 
 The tool can check multiple prefixes simultaneously:
+
 ```sh
-onion-vanity-address zwiebel cipolla cebolla
+onion-vanity-address --count 3 zwiebel cipolla cebolla
 ```
 
-It will output the first onion address that starts with any of the specified prefixes.
-When searching for multiple prefixes of varying lengths, shorter prefixes will appear more often across multiple runs.
+Example output:
+
+```console
+$ onion-vanity-address --count 3 zwiebel cipolla cebolla
+Searching zwiebel,cipolla,cebolla | elapsed 10s | tried 486.9M | 48.7M attempts/s | found 0/3 | remaining 3
+Found cipolla... cipollaabc...onion (1/3) after 29s and 1.4B attempts (48.7M attempts/s)
+Searching zwiebel,cipolla,cebolla | elapsed 40s | tried 1.9B | 48.7M attempts/s | found 1/3 | remaining 2
+Found cebolla... cebollaxyz...onion (2/3) after 1m5s and 3.2B attempts (48.7M attempts/s)
+Searching zwiebel,cipolla,cebolla | elapsed 1m20s | tried 3.9B | 48.7M attempts/s | found 2/3 | remaining 1
+Found zwiebel... zwiebeldef...onion (3/3) after 1m53s and 5.5B attempts (48.7M attempts/s)
+Wrote Tor service files to cipollaabc...onion/
+Wrote Tor service files to cebollaxyz...onion/
+Wrote Tor service files to zwiebeldef...onion/
+```
+
+It will output the first three onion addresses that start with any of the specified prefixes.
+
+When searching for multiple prefixes of varying lengths, shorter prefixes will appear more often.
+
+Use `--count` to change this behaviour:
+
+```sh
+onion-vanity-address --count 5 zwiebel cipolla cebolla
+```
 
 ### Client authorization
 
-To generate vanity [client authorization](https://community.torproject.org/onion-services/advanced/client-auth/) keypair use `--client` flag:
+To generate vanity [client authorization](https://community.torproject.org/onion-services/advanced/client-auth/) keypairs use the `--client` flag:
+
 ```console
-$ onion-vanity-address --client LEMON
-Found LEMON... in 0s after 14990923 attempts (63626192 attempts/s)
+$ onion-vanity-address --client --count 1 LEMON
+Found LEMON... (1/1) in 0s after 15.0M attempts (63.6M attempts/s)
 ---
 public_key: LEMON7P5L7FEZZEJJGQTC3PDFRHEOOBP3H2XXHRFQSD72OKKEE5Q
 private_key: AAADDFICRR46KLA52KV2QRIN6GUWIPEIVZZZUVZLC5UVE53QNMTA
 ```
 
-then add public key to `authorized_clients` directory:
+Client authorization keypairs are still printed to standard output.
+
+The `--start9` flag is only for Onion Service private key output and cannot be used together with `--client`.
+
+Then add the public key to the `authorized_clients` directory:
+
 ```console
 $ echo descriptor:x25519:LEMON7P5L7FEZZEJJGQTC3PDFRHEOOBP3H2XXHRFQSD72OKKEE5Q > /var/lib/tor/hidden_service/authorized_clients/lemon.auth
 $ systemctl reload tor
 ```
 
 To access the service via Tor Browser provide it the private key:
-```
+
+```text
 ┌────────────────────────────────┬───────────────────────────────────────────
 │ 🛈 Authentication required   🗙 │ ＋
 ├────────────────────────────────┴───────────────────────────────────────────
@@ -88,19 +216,24 @@ To access the service via Tor Browser provide it the private key:
 ```
 
 To see all flags and usage examples run:
+
 ```sh
 onion-vanity-address --help
 ```
 
 ## Performance
 
-The tool checks ~45'000'000 keys per second on a laptop:
+The tool checks around 45,000,000 keys per second on a laptop:
+
 ```console
-$ onion-vanity-address --timeout 20s goodluckwiththisprefix
-Stopped searching goodluckwiththisprefix... after 20s and 959763220 attempts (47985799 attempts/s)
+$ onion-vanity-address --timeout 20s --count 1 goodluckwiththisprefix
+Searching goodluckwiththisprefix | elapsed 10s | tried 480.1M | 48.0M attempts/s | found 0/1 | remaining 1
+Searching goodluckwiththisprefix | elapsed 20s | tried 959.8M | 48.0M attempts/s | found 0/1 | remaining 1
+Stopped searching [goodluckwiththisprefix]... after 20s and 959.8M attempts (48.0M attempts/s)
 ```
 
-which is ~2x faster than `mkp224o`:
+which is around 2x faster than `mkp224o`:
+
 ```console
 $ timeout 20 docker run ghcr.io/cathugger/mkp224o:master -s -y goodluckwiththisprefix
 sorting filters... done.
@@ -113,24 +246,36 @@ using 8 threads
 ```
 
 In practice, it finds a 6-character prefix within a minute.
+
 Each additional character increases search time by a factor of 32.
 
 ## Kubernetes
 
-Run distributed vanity address search in Kubernetes cluster using the [demo-k8s.yaml](demo-k8s.yaml) manifest
-without exposing the secret key to the cluster:
+Run distributed vanity address search in a Kubernetes cluster using the [demo-k8s.yaml](demo-k8s.yaml) manifest without exposing the secret key to the cluster.
+
+This distributed mode searches for an offset from a starting public key. Once the cluster finds a matching offset, apply that offset locally to the corresponding secret key.
 
 ```console
-$ # Locally generate secure starting keypair (or use existing one created by Tor)
-$ onion-vanity-address start
-Found start... in 1s after 26921387 attempts (43429741 attempts/s)
----
-hostname: startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion
-hs_ed25519_public_key: PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAACUwRne+J2A35is85MvD0Clj2SfEk52LqdHH80VuVlg+Q==
-hs_ed25519_secret_key: PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAABgZ5a7kuS0N1jaA12gtsqI87RPS1eqSj4KWpwXukWtV7pFj6gS200J96P8JDWTpvx000KF3r4l+xYcIJszhPZk
+$ # Locally generate one secure starting keypair
+$ onion-vanity-address --count 1 start
+Searching start | elapsed 1s | tried 43.4M | 43.4M attempts/s | found 0/1 | remaining 1
+Found start... startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion (1/1) after 1s and 43.4M attempts (43.4M attempts/s)
+Wrote Tor service files to startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion/
 
-$ # Edit demo-k8s.yaml to configure prefix, starting **public key**, parallelism, and resource limits 💸
+$ # The generated directory contains:
+$ ls startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion/
+hostname
+hs_ed25519_public_key
+hs_ed25519_secret_key
 
+$ # Base64-encode the public key file for use with --from / Kubernetes configuration
+$ base64 -w0 startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion/hs_ed25519_public_key
+PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAACUwRne+J2A35is85MvD0Clj2SfEk52LqdHH80VuVlg+Q==
+```
+
+Edit `demo-k8s.yaml` to configure the prefix, starting public key, parallelism, and resource limits.
+
+```console
 $ # Create search job
 $ kubectl apply -f demo-k8s.yaml
 job.batch/ova created
@@ -168,17 +313,20 @@ ova    Complete   1/999999      23m14s     23m44s
 
 $ # Get found offset from the logs
 $ kubectl logs jobs/ova
-Found lukovitsa... in 23m14s after 1003371311076 attempts (719798516 attempts/s)
+Found lukovitsa... lukovitsa6jy7sldxvdw7wwzdmf5sezbwgr5uf57kkhi3jep25g2d2id.onion (1/1) after 23m14s and 1.0T attempts (719.8M attempts/s)
 ---
 hostname: lukovitsa6jy7sldxvdw7wwzdmf5sezbwgr5uf57kkhi3jep25g2d2id.onion
 offset: sgowAsMLwBk=
 
-$ # Locally generate vanity keypair by offsetting the starting secret key
-$ echo PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAABgZ5a7kuS0N1jaA12gtsqI87RPS1eqSj4KWpwXukWtV7pFj6gS200J96P8JDWTpvx000KF3r4l+xYcIJszhPZk | onion-vanity-address --offset=sgowAsMLwBk=
----
-hostname: lukovitsa6jy7sldxvdw7wwzdmf5sezbwgr5uf57kkhi3jep27gzjlid.onion
-hs_ed25519_public_key: PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAABdFOqicgeTj8ljvUdv2tkbC9kTIbGj2he/Uo6NpI/XzQ==
-hs_ed25519_secret_key: PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAAAoaPTTqGQGyF3aA12gtsqI87RPS1eqSj4KWpwXukWtVyHuiixSBYjSDLiBwGmeqebH1FX7vsHRPBrojpTFiCGQ
+$ # Locally generate the vanity keypair by offsetting the starting secret key
+$ base64 -w0 startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion/hs_ed25519_secret_key \
+  | onion-vanity-address --offset=sgowAsMLwBk=
+Wrote Tor service files to lukovitsa6jy7sldxvdw7wwzdmf5sezbwgr5uf57kkhi3jep27gzjlid.onion/
+
+$ # Or write the offset result in Start9 format
+$ base64 -w0 startxxytwan7gfm6ojs6d2auwhwjhysjz3c5j2hd7grlokzmd4reoqd.onion/hs_ed25519_secret_key \
+  | onion-vanity-address --start9 --offset=sgowAsMLwBk=
+Wrote Start9 key to lukovitsa6jy7sldxvdw7wwzdmf5sezbwgr5uf57kkhi3jep27gzjlid.onion
 
 $ # Delete the job
 $ kubectl delete job ova
@@ -193,24 +341,26 @@ job.batch "ova" deleted
 ## The fastest search algorithm
 
 Tor Onion Service [address](https://github.com/torproject/torspec/blob/main/rend-spec-v3.txt) is derived from ed25519 public key.
+
 The tool generates candidate public keys until it finds one that has a specified prefix when encoded as onion address.
 
 ed25519 keypair consists of:
+
 * 32-byte secret key (scalar) - a random value that serves as the secret
 * 32-byte public key (point) - derived by scalar multiplication of the base point by the scalar
 
-ed25519 public key is 32-byte y-coordinate of a point on a [Twisted Edwards curve](https://datatracker.ietf.org/doc/html/rfc8032) equivalent to [Curve25519](https://datatracker.ietf.org/doc/html/rfc7748#section-4.1).
+ed25519 public key is a 32-byte y-coordinate of a point on a [Twisted Edwards curve](https://datatracker.ietf.org/doc/html/rfc8032) equivalent to [Curve25519](https://datatracker.ietf.org/doc/html/rfc7748#section-4.1).
 
 Both `mkp224o` and `onion-vanity-address` leverage additive properties of elliptic curves to avoid full scalar multiplication for each candidate key.
-Addition of points requires expensive field inversion operation and both tools utilize batch field inversion (Montgomery trick)
-to perform single field inversion per batch of candidate points.
 
-The key performance difference is that while `mkp224o` uses point arithmetic that calculates both coordinates for each candidate point,
-`onion-vanity-address` uses curve coordinate symmetry and calculates only y-coordinates to reduce number of field operations.
+Addition of points requires an expensive field inversion operation and both tools utilise batch field inversion, also known as the Montgomery trick, to perform a single field inversion per batch of candidate points.
 
-The algorithm has amortized cost **5M + 2A** per candidate key, where M is field multiplication and A is field addition.
+The key performance difference is that while `mkp224o` uses point arithmetic that calculates both coordinates for each candidate point, `onion-vanity-address` uses curve coordinate symmetry and calculates only y-coordinates to reduce the number of field operations.
+
+The algorithm has amortised cost **5M + 2A** per candidate key, where M is field multiplication and A is field addition.
 
 See also:
+
 * [vanity25519](https://github.com/AlexanderYastrebov/vanity25519) — Efficient Curve25519 vanity key generator.
 * [wireguard-vanity-key](https://github.com/AlexanderYastrebov/wireguard-vanity-key) — Fast WireGuard vanity key generator.
 * [age-vanity-keygen](https://github.com/AlexanderYastrebov/age-vanity-keygen) — Fast vanity age X25519 identity generator.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ This fork adds several practical improvements for generating and managing multip
   * `hostname`
   * `hs_ed25519_public_key`
   * `hs_ed25519_secret_key`
-* Use `--start9` to output the private key in the Start9 StartOS Tor plugin format.
+* Use `--start9` to output the private key in the Start9 StartOS Tor plugin format (base64 encoded).
 * Start9 output writes one file per generated hostname.
 * Each Start9 output file is named after the hostname and contains only the 88-character base64-encoded expanded secret key.
-* The live search status now updates in-place in the terminal instead of printing a new line for every update.
+* The live search status now updates in-place in the terminal instead of showing no progress during the process.
 * The progress report shows:
 
   * elapsed search time

--- a/demo-k8s.yaml
+++ b/demo-k8s.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       This Kubernetes Job configuration demonstrates how to run the
-      [onion-vanity-address](https://github.com/AlexanderYastrebov/onion-vanity-address)
+      [onion-vanity-address](https://github.com/xannythepleb/onion-vanity-address)
       tool in a distributed manner across multiple pods.
 spec:
   parallelism: 10 # 👈 Number of pods to run in parallel. See also resource limits below

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/AlexanderYastrebov/onion-vanity-address
+module github.com/xannythepleb/onion-vanity-address
 
 go 1.25.0
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -20,77 +21,85 @@ import (
 )
 
 const usage = `Usage:
-    onion-vanity-address [--client] [--from PUBLIC_KEY] [--timeout TIMEOUT] PREFIX [PREFIX]...
+    onion-vanity-address [--client] [--from PUBLIC_KEY] [--timeout TIMEOUT] [--count COUNT] PREFIX [PREFIX]...
+    onion-vanity-address [--start9] [--timeout TIMEOUT] [--count COUNT] PREFIX [PREFIX]...
     onion-vanity-address [--client] --offset OFFSET
+    onion-vanity-address [--start9] --offset OFFSET
 
 Options:
     --client                Search for a Client Authorization keypair instead of an Onion Service keypair.
+    --count COUNT           Stop after finding COUNT matching keys. Defaults to 3.
     --from PUBLIC_KEY       Start search from the given public key.
     --offset OFFSET         Add an offset to the secret keys read from standard input.
+    --start9                Write Onion Service secret keys as Start9 StartOS-compatible 88-character base64 files.
     --timeout TIMEOUT       Stop after the specified timeout (e.g., 10s, 5m, 1h).
 
-onion-vanity-address generates a new Onion Service ed25519 keypair with an onion address having one of the specified PREFIXes,
-and outputs it to standard output in base64-encoded YAML format.
+onion-vanity-address generates Onion Service ed25519 keypairs with onion addresses having one of the specified PREFIXes.
+By default it writes each matching Onion Service keypair to a directory named after the hostname. Each directory contains:
 
-In --client mode, onion-vanity-address generates a Client Authorization keypair with public key having one of the specified PREFIXes.
+    hostname
+    hs_ed25519_public_key
+    hs_ed25519_secret_key
 
-PREFIX must use base32 character set "` + onionBase32EncodingCharset + `" for Onion Servic keypair
-and "` + clientBase32EncodingCharset + `" for Client Authorization keypair.
+With --start9, it writes one file per hostname. The file is named after the hostname and contains the 88-character
+base64-encoded expanded secret key expected by Start9 StartOS's Tor plugin UI.
 
-In --from mode, onion-vanity-address starts the search from a specified public key and
-outputs the offset to the public key with the desired prefix.
+In --client mode, onion-vanity-address generates Client Authorization keypairs with public keys having one of the specified PREFIXes.
+Client keypairs are still printed to standard output.
+
+PREFIX must use base32 character set "` + onionBase32EncodingCharset + `" for Onion Service keypairs
+and "` + clientBase32EncodingCharset + `" for Client Authorization keypairs.
+
+In --from mode, onion-vanity-address starts the search from a specified public key and outputs matching offsets.
 The offset can be added to the corresponding secret key to derive the new keypair.
 
-In --offset mode, onion-vanity-address reads the secret key from standard input,
-adds the specified offset to it, and outputs the resulting keypair.
+In --offset mode, onion-vanity-address reads the secret key from standard input, adds the specified offset,
+and writes the resulting Onion Service keypair in the selected output format.
 
 Service examples:
 
-    # Generate a new service keypair with address having the specified prefix
-    $ onion-vanity-address allium
-    Found allium... in 12s after 558986486 attempts (48529996 attempts/s)
-    ---
-    hostname: alliumdye3it7ko4cuftoni4rlrupuobvio24ypz55qpzjzpvuetzhyd.onion
-    hs_ed25519_public_key: PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAAAC1ooweCbRP6ncFQs3NRyK40fRwaodrmH572D8py+tCQ==
-    hs_ed25519_secret_key: PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAAAQEW4Rhot7oroPaETlAEG3GPAntvJ1agF2c7A2AXmBW3WqAH0oUZ1hySvvZl3hc9dSAIc49h1UuCPZacOWp4vQ
+    # Generate three new service keypairs with addresses having any of the specified prefixes
+    $ onion-vanity-address test t3st testaddr
+    Searching test,t3st,testaddr | elapsed 10s | tried 564.0M | 56.4M attempts/s | found 1/3 | remaining 2
+    Found test... testabc...onion (1/3) after 12s and 676.8M attempts (56.4M attempts/s)
+    Wrote Tor service files to testabc...onion/
+
+    # Generate one Start9-compatible key
+    $ onion-vanity-address --start9 --count 1 test
+    Found test... testxyz...onion (1/1) after 5s and 282.0M attempts (56.4M attempts/s)
+    Wrote Start9 key to testxyz...onion
 
     # Find prefix offset from the specified public key
     $ onion-vanity-address --from PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAAAC1ooweCbRP6ncFQs3NRyK40fRwaodrmH572D8py+tCQ== cebula
-    Found cebula... in 2s after 78457550 attempts (44982483 attempts/s)
+    Found cebula... cebulasfa3b4ahol44ydvc2an6b4vgpjcguarwsj35dr6jbanveea4id.onion (1/3) after 2s and 78.5M attempts (44.9M attempts/s)
     ---
     hostname: cebulasfa3b4ahol44ydvc2an6b4vgpjcguarwsj35dr6jbanveea4id.onion
     offset: cIZ5Birj/cY=
 
-    # Apply offset to the secret key
+    # Apply offset to the secret key and write Tor service files
     $ echo PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAAAQEW4Rhot7oroPaETlAEG3GPAntvJ1agF2c7A2AXmBW3WqAH0oUZ1hySvvZl3hc9dSAIc49h1UuCPZacOWp4vQ \
     | onion-vanity-address --offset cIZ5Birj/cY=
-    ---
-    hostname: cebulasfa3b4ahol44ydvc2an6b4vgpjcguarwsj35dr6jbanxenrcqd.onion
-    hs_ed25519_public_key: PT0gZWQyNTUxOXYxLXB1YmxpYzogdHlwZTAgPT0AAAARA0WCRQbDwB3L5zA6i0Bvg8qZ6RGoCNpJ30cfJCBtyA==
-    hs_ed25519_secret_key: PT0gZWQyNTUxOXYxLXNlY3JldDogdHlwZTAgPT0AAABA/41ot1OvJr4PaETlAEG3GPAntvJ1agF2c7A2AXmBW/BnbLk2LgY3abEydc7heS5rhKByW/nafTlwifcgL0zO
+    Wrote Tor service files to cebulasfa3b4ahol44ydvc2an6b4vgpjcguarwsj35dr6jbanxenrcqd.onion/
 
 Client examples:
 
-    # Generate a new client authorization keypair with the specified prefix
-    $ onion-vanity-address --client LEMON
-    Found LEMON... in 0s after 14990923 attempts (63626192 attempts/s)
+    # Generate client authorization keypairs with the specified prefix
+    $ onion-vanity-address --client --count 1 LEMON
+    Found LEMON... in 0s after 15.0M attempts (63.6M attempts/s)
     ---
     public_key: LEMON7P5L7FEZZEJJGQTC3PDFRHEOOBP3H2XXHRFQSD72OKKEE5Q
     private_key: AAADDFICRR46KLA52KV2QRIN6GUWIPEIVZZZUVZLC5UVE53QNMTA
-
-    # Find prefix offset from the specified public key
-    $ onion-vanity-address --client --from LEMON7P5L7FEZZEJJGQTC3PDFRHEOOBP3H2XXHRFQSD72OKKEE5Q TOMATO
-    Found TOMATO... in 16s after 1071246687 attempts (65052983 attempts/s)
-    ---
-    public_key: TOMATOWHTLC3ERVBD2D6V5DENSWPBAHYUKJNYNUALO3CJB2C2BZQ
-    offset: 0mtckGJcwbs=
-
-    # Apply offset to the private key
-    $ echo AAADDFICRR46KLA52KV2QRIN6GUWIPEIVZZZUVZLC5UVE53QNMTA | onion-vanity-address --client --offset 0mtckGJcwbs=
-    ---
-    public_key: TOMATOWHTLC3ERVBD2D6V5DENSWPBAHYUKJNYNUALO3CJB2C2BZQ
-    private_key: FDZEVAT7U4PFEJQ52KV2QRIN6GUWIPEIVZZZUVZLC5UVE53QNMTA
 `
+
+type searchOptions struct {
+	count  int
+	start9 bool
+}
+
+type foundKey struct {
+	publicKey []byte
+	offset    *big.Int
+}
 
 func must[T any](v T, err error) T {
 	if err != nil {
@@ -113,13 +122,23 @@ func main() {
 	var fromFlag string
 	var offsetFlag string
 	var timeoutFlag time.Duration
+	var countFlag int
+	var start9Flag bool
 
 	flag.Usage = func() { fmt.Fprint(os.Stderr, usage) }
 	flag.BoolVar(&clientFlag, "client", false, "search for a Client Authorization keypair instead of an Onion Service keypair")
+	flag.IntVar(&countFlag, "count", 3, "stop after finding this many matching keys")
 	flag.StringVar(&fromFlag, "from", "", "public key to start search from")
 	flag.StringVar(&offsetFlag, "offset", "", "offset to add to the secret key read from stdin")
+	flag.BoolVar(&start9Flag, "start9", false, "write Start9 StartOS-compatible 88-character base64 secret key files")
 	flag.DurationVar(&timeoutFlag, "timeout", 0, "stop after specified timeout")
 	flag.Parse()
+
+	check(countFlag > 0, "--count must be greater than zero")
+	check(!(clientFlag && start9Flag), "--start9 can only be used with Onion Service keypairs")
+	check(!(fromFlag != "" && start9Flag), "--start9 can not be used with --from because --from only outputs offsets")
+
+	opts := searchOptions{count: countFlag, start9: start9Flag}
 
 	if offsetFlag != "" {
 		check(fromFlag == "", "--from can not be used with --offset")
@@ -131,7 +150,7 @@ func main() {
 		if clientFlag {
 			offsetClientKey(offset)
 		} else {
-			offsetServiceKey(offset)
+			offsetServiceKey(offset, opts)
 		}
 		return
 	}
@@ -147,9 +166,9 @@ func main() {
 	}
 
 	if clientFlag {
-		searchClientKey(ctx, flag.Args(), fromFlag)
+		searchClientKey(ctx, flag.Args(), fromFlag, opts)
 	} else {
-		searchServiceKey(ctx, flag.Args(), fromFlag)
+		searchServiceKey(ctx, flag.Args(), fromFlag, opts)
 	}
 }
 
@@ -163,33 +182,37 @@ func offsetClientKey(offset *big.Int) {
 	fmt.Printf("private_key: %s\n", clientBase32Encoding.EncodeToString(vanitySecretKey))
 }
 
-func offsetServiceKey(offset *big.Int) {
+func offsetServiceKey(offset *big.Int, opts searchOptions) {
 	startSecretKey := must(readServiceSecretKey(os.Stdin))
 	vanitySecretKey := must(add(startSecretKey, offset))
 	vanityPublicKey := must(publicKeyFor(vanitySecretKey))
+	address := encodeOnionAddress(vanityPublicKey)
 
-	fmt.Println("---")
-	fmt.Printf("%s: %s\n", hostnameFileName, encodeOnionAddress(vanityPublicKey))
-	fmt.Printf("%s: %s\n", publicKeyFileName, encodeServicePublicKey(vanityPublicKey))
-	fmt.Printf("%s: %s\n", secretKeyFileName, encodeServiceSecretKey(vanitySecretKey))
+	path := must(writeServiceKey(address, vanityPublicKey, vanitySecretKey, opts.start9))
+	printOutputPath(path, opts.start9)
 }
 
-func searchClientKey(ctx context.Context, prefixes []string, from string) {
-	var startSecretKey, startPublicKey []byte
-	if from != "" {
-		startPublicKey = must(decodeClientPublicKey(from))
-	} else {
-		startSecretKey = make([]byte, 32)
-		rand.Read(startSecretKey)
+func searchClientKey(ctx context.Context, prefixes []string, from string, opts searchOptions) {
+	for i := 1; i <= opts.count; i++ {
+		var startSecretKey, startPublicKey []byte
+		if from != "" {
+			startPublicKey = must(decodeClientPublicKey(from))
+		} else {
+			startSecretKey = make([]byte, 32)
+			must(rand.Read(startSecretKey))
+			startPublicKey = must(clientPublicKeyFor(startSecretKey))
+		}
 
-		startPublicKey = must(clientPublicKeyFor(startSecretKey))
-	}
+		start := time.Now()
+		found, vanityPublicKey, attempts := parallel(vanity25519.Search, ctx, startPublicKey, must(matchAnyOf(prefixes, clientMatch)))
+		elapsed := time.Since(start)
 
-	start := time.Now()
-	found, vanityPublicKey, attempts := parallel(vanity25519.Search, ctx, startPublicKey, must(matchAnyOf(prefixes, clientMatch)))
-	elapsed := time.Since(start)
+		if found == nil {
+			fmt.Fprintf(os.Stderr, "Stopped searching %v... after %s and %s attempts (%s attempts/s)\n",
+				prefixes, elapsed.Round(time.Second), formatCompactUint(attempts), formatCompactRate(attempts, elapsed))
+			os.Exit(2)
+		}
 
-	if found != nil {
 		var vanitySecretKey []byte
 		if len(startSecretKey) > 0 {
 			vanitySecretKey = must(vanity25519.Add(startSecretKey, found))
@@ -199,8 +222,8 @@ func searchClientKey(ctx context.Context, prefixes []string, from string) {
 		vanityPublicKeyEncoded := clientBase32Encoding.EncodeToString(vanityPublicKey)
 		prefix := longestMatching(prefixes, vanityPublicKeyEncoded)
 
-		fmt.Fprintf(os.Stderr, "Found %s... in %s after %d attempts (%.0f attempts/s)\n",
-			prefix, elapsed.Round(time.Second), attempts, float64(attempts)/elapsed.Seconds())
+		fmt.Fprintf(os.Stderr, "Found %s... (%d/%d) in %s after %s attempts (%s attempts/s)\n",
+			prefix, i, opts.count, elapsed.Round(time.Second), formatCompactUint(attempts), formatCompactRate(attempts, elapsed))
 
 		fmt.Println("---")
 		fmt.Printf("public_key: %s\n", vanityPublicKeyEncoded)
@@ -209,54 +232,159 @@ func searchClientKey(ctx context.Context, prefixes []string, from string) {
 		} else {
 			fmt.Printf("offset: %s\n", base64.StdEncoding.EncodeToString(found.Bytes()))
 		}
-	} else {
-		fmt.Fprintf(os.Stderr, "Stopped searching %v... after %s and %d attempts (%.0f attempts/s)\n",
-			prefixes, elapsed.Round(time.Second), attempts, float64(attempts)/elapsed.Seconds())
-		os.Exit(2)
 	}
 }
 
-func searchServiceKey(ctx context.Context, prefixes []string, from string) {
+func searchServiceKey(ctx context.Context, prefixes []string, from string, opts searchOptions) {
 	var startSecretKey, startPublicKey []byte
 	if from != "" {
 		startPublicKey = must(decodeServicePublicKey(from))
 	} else {
 		startSecretKey = make([]byte, 32)
-		rand.Read(startSecretKey)
-
+		must(rand.Read(startSecretKey))
 		startPublicKey = must(publicKeyFor(startSecretKey))
 	}
 
 	start := time.Now()
-	found, vanityPublicKey, attempts := parallel(search, ctx, startPublicKey, must(matchAnyOf(prefixes, addressMatch)))
-	elapsed := time.Since(start)
+	var attemptsTotal atomic.Uint64
+	var foundTotal atomic.Int64
 
-	if found != nil {
-		var vanitySecretKey []byte
-		if len(startSecretKey) > 0 {
-			vanitySecretKey = must(add(startSecretKey, found))
-			vanityPublicKey = must(publicKeyFor(vanitySecretKey))
-		}
+	progressCtx, stopProgress := context.WithCancel(context.Background())
+	defer stopProgress()
+	go reportProgress(progressCtx, start, &attemptsTotal, &foundTotal, opts.count, prefixes)
 
-		address := encodeOnionAddress(vanityPublicKey)
+	results, attempts := parallelService(ctx, startPublicKey, must(matchAnyOf(prefixes, addressMatch)), opts.count, &attemptsTotal, func(index int, publicKey []byte, offset *big.Int) {
+		foundTotal.Store(int64(index))
+		address := encodeOnionAddress(publicKey)
 		prefix := longestMatching(prefixes, address)
+		elapsed := time.Since(start)
 
-		fmt.Fprintf(os.Stderr, "Found %s... in %s after %d attempts (%.0f attempts/s)\n",
-			prefix, elapsed.Round(time.Second), attempts, float64(attempts)/elapsed.Seconds())
+		clearProgressLine()
+		fmt.Fprintf(os.Stderr, "Found %s... %s (%d/%d) after %s and %s attempts (%s attempts/s)\n",
+			prefix, address, index, opts.count, elapsed.Round(time.Second), formatCompactUint(attemptsTotal.Load()), formatCompactRate(attemptsTotal.Load(), elapsed))
+	})
 
-		fmt.Println("---")
-		fmt.Printf("%s: %s\n", hostnameFileName, address)
-		if len(vanitySecretKey) > 0 {
-			fmt.Printf("%s: %s\n", publicKeyFileName, encodeServicePublicKey(vanityPublicKey))
-			fmt.Printf("%s: %s\n", secretKeyFileName, encodeServiceSecretKey(vanitySecretKey))
-		} else {
-			fmt.Printf("offset: %s\n", base64.StdEncoding.EncodeToString(found.Bytes()))
-		}
-	} else {
-		fmt.Fprintf(os.Stderr, "Stopped searching %v... after %s and %d attempts (%.0f attempts/s)\n",
-			prefixes, elapsed.Round(time.Second), attempts, float64(attempts)/elapsed.Seconds())
+	stopProgress()
+	clearProgressLine()
+
+	if len(results) == 0 {
+		elapsed := time.Since(start)
+		fmt.Fprintf(os.Stderr, "Stopped searching %v... after %s and %s attempts (%s attempts/s)\n",
+			prefixes, elapsed.Round(time.Second), formatCompactUint(attempts), formatCompactRate(attempts, elapsed))
 		os.Exit(2)
 	}
+
+	for _, result := range results {
+		if len(startSecretKey) == 0 {
+			address := encodeOnionAddress(result.publicKey)
+			fmt.Println("---")
+			fmt.Printf("%s: %s\n", hostnameFileName, address)
+			fmt.Printf("offset: %s\n", base64.StdEncoding.EncodeToString(result.offset.Bytes()))
+			continue
+		}
+
+		vanitySecretKey := must(add(startSecretKey, result.offset))
+		vanityPublicKey := must(publicKeyFor(vanitySecretKey))
+		address := encodeOnionAddress(vanityPublicKey)
+		path := must(writeServiceKey(address, vanityPublicKey, vanitySecretKey, opts.start9))
+		printOutputPath(path, opts.start9)
+	}
+
+	if len(results) < opts.count {
+		elapsed := time.Since(start)
+		fmt.Fprintf(os.Stderr, "Stopped after finding %d/%d keys in %s and %s attempts (%s attempts/s)\n",
+			len(results), opts.count, elapsed.Round(time.Second), formatCompactUint(attempts), formatCompactRate(attempts, elapsed))
+	}
+}
+
+func writeServiceKey(address string, publicKey, secretKey []byte, start9 bool) (string, error) {
+	if start9 {
+		path := filepath.Clean(address)
+		if err := os.WriteFile(path, []byte(encodeStart9ServiceSecretKey(secretKey)), 0o600); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+
+	dir := filepath.Clean(address)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, hostnameFileName), []byte(address+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, publicKeyFileName), serializeServicePublicKey(publicKey), 0o644); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(dir, secretKeyFileName), serializeServiceSecretKey(secretKey), 0o600); err != nil {
+		return "", err
+	}
+	return dir + string(os.PathSeparator), nil
+}
+
+func printOutputPath(path string, start9 bool) {
+	if start9 {
+		fmt.Fprintf(os.Stderr, "Wrote Start9 key to %s\n", path)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Wrote Tor service files to %s\n", path)
+}
+
+func reportProgress(ctx context.Context, start time.Time, attempts *atomic.Uint64, found *atomic.Int64, target int, prefixes []string) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	render := func() {
+		elapsed := time.Since(start).Round(time.Second)
+		foundCount := int(found.Load())
+		remaining := target - foundCount
+		if remaining < 0 {
+			remaining = 0
+		}
+
+		fmt.Fprintf(os.Stderr, "\r\033[KSearching %s | elapsed %s | tried %s | %s attempts/s | found %d/%d | remaining %d",
+			strings.Join(prefixes, ","), elapsed, formatCompactUint(attempts.Load()), formatCompactRate(attempts.Load(), time.Since(start)), foundCount, target, remaining)
+	}
+
+	render()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			render()
+		}
+	}
+}
+
+func clearProgressLine() {
+	fmt.Fprint(os.Stderr, "\r\033[K")
+}
+
+func formatCompactRate(attempts uint64, elapsed time.Duration) string {
+	seconds := elapsed.Seconds()
+	if seconds <= 0 {
+		return "0"
+	}
+	return formatCompactFloat(float64(attempts) / seconds)
+}
+
+func formatCompactUint(n uint64) string {
+	return formatCompactFloat(float64(n))
+}
+
+func formatCompactFloat(n float64) string {
+	units := []string{"", "K", "M", "B", "T", "P", "E"}
+	unit := 0
+	for n >= 1000 && unit < len(units)-1 {
+		n /= 1000
+		unit++
+	}
+
+	if unit == 0 {
+		return fmt.Sprintf("%.0f", n)
+	}
+	return fmt.Sprintf("%.1f%s", n, units[unit])
 }
 
 func clientMatch(prefix string) (func([]byte) bool, error) {
@@ -295,7 +423,9 @@ func parallel(search searchFunc, ctx context.Context, startPublicKey []byte, tes
 	var attemptsTotal atomic.Uint64
 	var wg sync.WaitGroup
 	for range runtime.GOMAXPROCS(0) {
-		wg.Go(func() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
 			startOffset, _ := rand.Int(rand.Reader, new(big.Int).SetUint64(1<<64-1))
 			attempts := search(ctx, startPublicKey, startOffset, 4096, test, func(pk []byte, offset *big.Int) {
 				if result.CompareAndSwap(nil, offset) {
@@ -304,9 +434,53 @@ func parallel(search searchFunc, ctx context.Context, startPublicKey []byte, tes
 				}
 			})
 			attemptsTotal.Add(attempts)
-		})
+		}()
 	}
 	wg.Wait()
 
 	return result.Load(), vanityPublicKey, attemptsTotal.Load()
+}
+
+func parallelService(ctx context.Context, startPublicKey []byte, test func([]byte) bool, target int, attemptsTotal *atomic.Uint64, onFound func(index int, publicKey []byte, offset *big.Int)) ([]foundKey, uint64) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var mu sync.Mutex
+	var results []foundKey
+	var wg sync.WaitGroup
+
+	for range runtime.GOMAXPROCS(0) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			startOffset, _ := rand.Int(rand.Reader, new(big.Int).SetUint64(1<<64-1))
+			searchWithProgress(ctx, startPublicKey, startOffset, 4096, test, func(delta uint64) {
+				attemptsTotal.Add(delta)
+			}, func(pk []byte, offset *big.Int) {
+				pkCopy := append([]byte(nil), pk...)
+				offsetCopy := new(big.Int).Set(offset)
+
+				mu.Lock()
+				if len(results) >= target {
+					mu.Unlock()
+					return
+				}
+
+				results = append(results, foundKey{publicKey: pkCopy, offset: offsetCopy})
+				index := len(results)
+				if index >= target {
+					cancel()
+				}
+				mu.Unlock()
+
+				if onFound != nil {
+					onFound(index, pkCopy, offsetCopy)
+				}
+			})
+		}()
+	}
+
+	wg.Wait()
+	return results, attemptsTotal.Load()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/AlexanderYastrebov/onion-vanity-address/internal/assert"
-	"github.com/AlexanderYastrebov/onion-vanity-address/internal/require"
+	"github.com/xannythepleb/onion-vanity-address/internal/assert"
+	"github.com/xannythepleb/onion-vanity-address/internal/require"
 )
 
 func TestFixture(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/AlexanderYastrebov/onion-vanity-address/internal/assert"
@@ -42,4 +44,85 @@ func TestFixture(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []byte(fixture+"\n"), hostnameBytes)
+}
+
+func TestStart9ServiceSecretKeyEncoding(t *testing.T) {
+	const fixture = "onionjifniegtjbbifet65goa2siqubne6n2qfhiksryfvsbdhdl5zid.onion"
+
+	secretKeyBytes, err := os.ReadFile(filepath.Join("testdata", fixture, secretKeyFileName))
+	require.NoError(t, err)
+
+	secretKeyBytes = bytes.TrimPrefix(secretKeyBytes, []byte(secretKeyFilePrefix))
+	secretKey := secretKeyBytes[:32]
+
+	encoded := encodeStart9ServiceSecretKey(secretKey)
+	assert.Equal(t, 88, len(encoded))
+	assert.True(t, strings.HasSuffix(encoded, "=="))
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, expandServiceSecretKey(secretKey), decoded)
+}
+
+func TestWriteServiceKeyTorFiles(t *testing.T) {
+	const fixture = "onionjifniegtjbbifet65goa2siqubne6n2qfhiksryfvsbdhdl5zid.onion"
+
+	secretFile, err := os.ReadFile(filepath.Join("testdata", fixture, secretKeyFileName))
+	require.NoError(t, err)
+	publicFile, err := os.ReadFile(filepath.Join("testdata", fixture, publicKeyFileName))
+	require.NoError(t, err)
+
+	secretKey := bytes.TrimPrefix(secretFile, []byte(secretKeyFilePrefix))[:32]
+	publicKey := bytes.TrimPrefix(publicFile, []byte(publicKeyFilePrefix))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	tmp := t.TempDir()
+	require.NoError(t, os.Chdir(tmp))
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
+
+	path, err := writeServiceKey(fixture, publicKey, secretKey, false)
+	require.NoError(t, err)
+	assert.Equal(t, fixture+string(os.PathSeparator), path)
+
+	hostname, err := os.ReadFile(filepath.Join(fixture, hostnameFileName))
+	require.NoError(t, err)
+	assert.Equal(t, []byte(fixture+"\n"), hostname)
+
+	writtenPublic, err := os.ReadFile(filepath.Join(fixture, publicKeyFileName))
+	require.NoError(t, err)
+	assert.Equal(t, serializeServicePublicKey(publicKey), writtenPublic)
+
+	writtenSecret, err := os.ReadFile(filepath.Join(fixture, secretKeyFileName))
+	require.NoError(t, err)
+	assert.Equal(t, serializeServiceSecretKey(secretKey), writtenSecret)
+}
+
+func TestWriteServiceKeyStart9File(t *testing.T) {
+	const fixture = "onionjifniegtjbbifet65goa2siqubne6n2qfhiksryfvsbdhdl5zid.onion"
+
+	secretFile, err := os.ReadFile(filepath.Join("testdata", fixture, secretKeyFileName))
+	require.NoError(t, err)
+	secretKey := bytes.TrimPrefix(secretFile, []byte(secretKeyFilePrefix))[:32]
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	tmp := t.TempDir()
+	require.NoError(t, os.Chdir(tmp))
+	defer func() { require.NoError(t, os.Chdir(cwd)) }()
+
+	path, err := writeServiceKey(fixture, nil, secretKey, true)
+	require.NoError(t, err)
+	assert.Equal(t, fixture, path)
+
+	written, err := os.ReadFile(fixture)
+	require.NoError(t, err)
+	assert.Equal(t, encodeStart9ServiceSecretKey(secretKey), string(written))
+}
+
+func TestFormatCompactUint(t *testing.T) {
+	assert.Equal(t, "999", formatCompactUint(999))
+	assert.Equal(t, "1.5K", formatCompactUint(1500))
+	assert.Equal(t, "56.4M", formatCompactUint(56353081))
+	assert.Equal(t, "75.5B", formatCompactUint(75522209283))
 }

--- a/prefix_test.go
+++ b/prefix_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/AlexanderYastrebov/onion-vanity-address/internal/assert"
+	"github.com/xannythepleb/onion-vanity-address/internal/assert"
 )
 
 func TestDecodePrefixBits(t *testing.T) {

--- a/search.go
+++ b/search.go
@@ -28,6 +28,10 @@ var _B8 = new(edwards25519.Point).MultByCofactor(edwards25519.NewGeneratorPoint(
 // The search continues until context is done and returns number of generated candidates.
 // The function panics if batchSize is not positive and even, or if startPublicKey is not a valid edwards25519 public key.
 func search(ctx context.Context, startPublicKey []byte, startOffset *big.Int, batchSize int, accept func(candidatePublicKey []byte) bool, yield func(publicKey []byte, offset *big.Int)) uint64 {
+	return searchWithProgress(ctx, startPublicKey, startOffset, batchSize, accept, nil, yield)
+}
+
+func searchWithProgress(ctx context.Context, startPublicKey []byte, startOffset *big.Int, batchSize int, accept func(candidatePublicKey []byte) bool, progress func(attempts uint64), yield func(publicKey []byte, offset *big.Int)) uint64 {
 	if startOffset == nil || startOffset.Sign() == -1 {
 		panic("startOffset must be non-negative")
 	}
@@ -75,10 +79,11 @@ func search(ctx context.Context, startPublicKey []byte, startOffset *big.Int, ba
 	// as well as the center point p.
 	//
 	// Complexity: (5M + 2A)*batchSize + 278M + 9A
+	attempts := uint64(0)
 	for i := uint64(batchSize / 2); ; i += uint64(batchSize + 1) {
 		select {
 		case <-ctx.Done():
-			return i - uint64(batchSize/2)
+			return attempts
 		default:
 		}
 
@@ -140,6 +145,12 @@ func search(ctx context.Context, startPublicKey []byte, startOffset *big.Int, ba
 		if accept(yb[:]) {
 			offset := new(big.Int).Add(startOffset, new(big.Int).SetUint64(i))
 			yield(slices.Clone(yb[:]), offset)
+		}
+
+		batchAttempts := uint64(batchSize + 1)
+		attempts += batchAttempts
+		if progress != nil {
+			progress(batchAttempts)
 		}
 
 		// Complexity: 3M

--- a/search_test.go
+++ b/search_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"filippo.io/edwards25519"
-	"github.com/AlexanderYastrebov/onion-vanity-address/internal/assert"
-	"github.com/AlexanderYastrebov/onion-vanity-address/internal/require"
+	"github.com/xannythepleb/onion-vanity-address/internal/assert"
+	"github.com/xannythepleb/onion-vanity-address/internal/require"
 )
 
 func TestSearch(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -103,15 +103,24 @@ func serializeServicePublicKey(publicKey []byte) []byte {
 	return buf
 }
 
-func encodeServiceSecretKey(publicKey []byte) string {
-	return base64.StdEncoding.EncodeToString(serializeServiceSecretKey(publicKey))
+func encodeServiceSecretKey(secretKey []byte) string {
+	return base64.StdEncoding.EncodeToString(serializeServiceSecretKey(secretKey))
+}
+
+func encodeStart9ServiceSecretKey(secretKey []byte) string {
+	return base64.StdEncoding.EncodeToString(expandServiceSecretKey(secretKey))
 }
 
 // serializeServiceSecretKey returns the content of hs_ed25519_secret_key file.
 func serializeServiceSecretKey(secretKey []byte) []byte {
-	buf := make([]byte, 0, 96)
+	buf := make([]byte, 0, secretKeyFileLength)
 	buf = append(buf, secretKeyFilePrefix...)
+	buf = append(buf, expandServiceSecretKey(secretKey)...)
+	return buf
+}
 
+// expandServiceSecretKey returns the 64-byte expanded private key stored after Tor's hs_ed25519_secret_key header.
+func expandServiceSecretKey(secretKey []byte) []byte {
 	// From https://gitlab.torproject.org/tpo/core/tor/-/blob/main/src/lib/crypt_ops/crypto_ed25519.h#L27
 	//
 	//  * Note that we store secret keys in an expanded format that doesn't match
@@ -128,6 +137,5 @@ func serializeServiceSecretKey(secretKey []byte) []byte {
 	hs[0] &= 248
 	hs[31] &= 63
 	hs[31] |= 64
-	buf = append(buf, hs[:]...)
-	return buf
+	return hs[:]
 }


### PR DESCRIPTION
Made a fork to add these features: https://github.com/xannythepleb/onion-vanity-address

Some of it mkp224o does, e.g. generating multiple addresses for the same keyword and putting the keys in the file structure to make importing into torrc easier.

## Changes:

* The tool now keeps searching until it has found three matching Onion Service addresses by default.
* Use `--count` to choose how many matches to find before stopping.

  * Example: `--count 1`
  * Example: `--count 5`
* Normal Tor output now writes each generated Onion Service keypair to its own directory named after the hostname.
* Each normal Tor output directory contains the standard Onion Service files:

  * `hostname`
  * `hs_ed25519_public_key`
  * `hs_ed25519_secret_key`
* Use `--start9` to output the private key in the Start9 StartOS Tor plugin format (base64 encoded).
* Start9 output writes one file per generated hostname.
* Each Start9 output file is named after the hostname and contains only the 88-character base64-encoded expanded secret key.
* The live search status now updates in-place in the terminal instead of showing no progress during the process.
* The progress report shows:

  * elapsed search time
  * total attempts tried
  * attempts per second
  * how many matching keys have been found
  * how many are still remaining
* When a matching key is found, the tool prints it immediately while continuing the search.
* Large numbers are now shown in a short readable format.

  * Example: `56.4M attempts/s`
  * Example: `75.5B` total attempts